### PR TITLE
Fixed a few css issues on mini and full version.

### DIFF
--- a/index.vue
+++ b/index.vue
@@ -60,6 +60,9 @@ export default {
   color: black;
   letter-spacing: -0.2px;
   background: linear-gradient(90deg, #a26f3e 50%, #ebd188 50%);
+  
+  /* fixes for missing el-dialog__body in mini preview */
+  font-size: 14px;
   word-break: normal;
 }
 

--- a/index.vue
+++ b/index.vue
@@ -60,6 +60,7 @@ export default {
   color: black;
   letter-spacing: -0.2px;
   background: linear-gradient(90deg, #a26f3e 50%, #ebd188 50%);
+  word-break: normal;
 }
 
 .left {


### PR DESCRIPTION
element-ui set word-break in selector .el-dialog__body to break-all. This is only seen on the print version, since the preview does not use el-dialog__body.

The css selector .card will overwrite this setting to use normal word-breaking.